### PR TITLE
Define long() for Python 3

### DIFF
--- a/plugins/fusionio.py
+++ b/plugins/fusionio.py
@@ -77,6 +77,11 @@ import time
 import re
 import subprocess
 
+try:
+   long        # Python 2
+except NameError:
+   long = int  # Python 3
+
 os_name = platform.system()
 host_name = socket.gethostbyaddr(socket.gethostname())[0]
 host_types = ['app', 'db', 'ffx', 'indexer', 'search', 'other']


### PR DESCRIPTION
__long()__ was removed in Python 3 in favor of __int()__.  This PR ensures that lines 168 and 170 operate the same in both Python 2 and Python 3.


flake8 testing of https://github.com/salesforce/LinuxTelemetry on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./plugins/fusionio.py:163:19: F821 undefined name 'long'
            val = long(float(val_str.replace(',', '')))
                  ^
./plugins/fusionio.py:165:19: F821 undefined name 'long'
            val = long(val_str.replace(',', ''))
                  ^
./plugins/fusionio.py:209:59: F821 undefined name 'cmd_get_erase_blocks'
      collectd.warning('get_block_erases: %s missing?' % (cmd_get_erase_blocks))
                                                          ^
3     F821 undefined name 'long'
3
```